### PR TITLE
Link with the POSIX threads library.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CC       ?= gcc
 CFLAGS   ?= -Wall -g 
 
 CXX      ?= g++
-CXXFLAGS ?= -Wall -g -std=c++0x -o $(TARGET)
+CXXFLAGS ?= -Wall -g -std=c++0x -pthread -o $(TARGET)
 
 COBJS     = source/hid.o
 CPPOBJS   = source/main.o source/tools.o


### PR DESCRIPTION
First, thank you for this awesome project!

When using a modern linker, the project fails to link with the POSIX thread library. You can read more about the problem [here](https://stackoverflow.com/a/55086637). The problem can be fixed by adding the -pthread flag to CXXFLAGS.